### PR TITLE
Add publishing pipeline

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+registry=https://pkgs.dev.azure.com/mobisysgmbh/_packaging/mobisys/npm/registry/
+always-auth=true

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -1,0 +1,28 @@
+name: $(Date:yyyyMMdd)$(Rev:.r)
+
+# no CI trigger, must be started manual
+trigger: none
+
+# no pull request triggers
+pr: none
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+stages:
+- stage: Publish
+  displayName: 'Publish'
+  jobs:
+  - job: PublishToAzureArtifacts
+    displayName: 'Only Master: Publish to Azure Artifacts'
+    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+    steps:
+    - task: npmAuthenticate@0
+      displayName: Setup authentication for Azure DevOps npm Feed
+      inputs:
+        workingFile: .npmrc
+    - script: |
+        npm config get registry
+        npm publish
+      displayName: 'npm publish'
+

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -18,11 +18,10 @@ stages:
     condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
     steps:
     - task: npmAuthenticate@0
-      displayName: Setup authentication for Azure DevOps npm Feed
+      displayName: Setup authentication for AzureDevOps npm feed
       inputs:
         workingFile: .npmrc
     - script: |
-        npm config get registry
         npm publish
-      displayName: 'npm publish'
+      displayName: 'Publish npm package'
 


### PR DESCRIPTION
Add AzureDevOps Pipeline for publishing a NPM package to the private Mobisys NPM registry.
- no build triggers
- only from master branch
- publish into private Mobisys feed